### PR TITLE
refactor: rename Api to API

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ A collection of cool things made by the Eludris comminity.
 
 ## Eludris (Project)
 
-- [Api Wrappers](#eludris-api-wrappers)
+- [API Wrappers](#eludris-api-wrappers)
 
 ### Eludris API wrappers
 


### PR DESCRIPTION
This changes `Api` to `API` because API stands for something, but would very much look weird as `A.P.I.` yes.