### PR TITLE
feat: add pydris to API wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,6 @@ A collection of cool things made by the Eludris comminity.
 #### Python
 
 - [eludris.py](https://github.com/teaishealthy/eludris.py)
+- [pydris](https://github.com/EnokiUN/pydris)
 
 ## Cognite

--- a/README.md
+++ b/README.md
@@ -10,6 +10,6 @@ A collection of cool things made by the Eludris comminity.
 #### Python
 
 - [eludris.py](https://github.com/teaishealthy/eludris.py)
-- [pydris](https://github.com/EnokiUN/pydris)
+- [pydris](https://github.com/EnokiUN/pydris): A simple asynchronous wrapper for the Eludris API 
 
 ## Cognite


### PR DESCRIPTION
This adds the `pydris` mdoule to the API wrappers section of the README file.